### PR TITLE
MINT-01-Remove-Mary

### DIFF
--- a/packages/electron/scripts/calc-fee.sh
+++ b/packages/electron/scripts/calc-fee.sh
@@ -1,7 +1,6 @@
 alias cardano-cli="/Applications/Daedalus\ Testnet.app/Contents/MacOS/cardano-cli"
 
 cardano-cli transaction build-raw \
-  --mary-era \
   --fee 0 \
   --tx-in $TX_HASH#$TX_IX \
   --tx-out="$TX_OUT_STRING" \

--- a/packages/electron/scripts/get-or-create-address.sh
+++ b/packages/electron/scripts/get-or-create-address.sh
@@ -25,7 +25,7 @@ if [ ! -d "$APP_DATA_DIR/data" ]; then
 
   cardano-cli query protocol-parameters \
     --testnet-magic $TESTNET_ID \
-    --mary-era \
+  
     --out-file "$APP_DATA_DIR/data/protocol.json"
 
   mkdir "$APP_DATA_DIR/data/policy"

--- a/packages/electron/scripts/mint.sh
+++ b/packages/electron/scripts/mint.sh
@@ -1,7 +1,7 @@
 alias cardano-cli="/Applications/Daedalus\ Testnet.app/Contents/MacOS/cardano-cli"
 
 cardano-cli transaction build-raw \
-  --mary-era \
+
   --fee $TX_FEE \
   --tx-in $TX_HASH#$TX_IX \
   --tx-out "$TX_OUT_STRING" \

--- a/packages/electron/scripts/query-address.sh
+++ b/packages/electron/scripts/query-address.sh
@@ -1,5 +1,4 @@
 alias cardano-cli="/Applications/Daedalus\ Testnet.app/Contents/MacOS/cardano-cli"
 
 cardano-cli query utxo --address $(< "$APP_DATA_DIR/data/payment.addr") \
-  --testnet-magic $TESTNET_ID \
-  --mary-era
+  --testnet-magic $TESTNET_ID


### PR DESCRIPTION
A pretty cool repo from the early Plutus days.
Unfortunately not maintained, but I wanted to use it to mint items for testing.

This PR removes the --mary-era arg.